### PR TITLE
Change MSI endpoint test to be more robust

### DIFF
--- a/flask_keyvault/__init__.py
+++ b/flask_keyvault/__init__.py
@@ -83,7 +83,7 @@ class KeyVault(object):
         """
 
         credentials = None
-        if "APPSETTING_WEBSITE_SITE_NAME" in os.environ:
+        if os.getenv("MSI_ENDPOINT"):
             credentials = MSIAuthentication(
                 resource=self.AUTH_RESOURCE
             )

--- a/flask_keyvault/__init__.py
+++ b/flask_keyvault/__init__.py
@@ -83,7 +83,7 @@ class KeyVault(object):
         """
 
         credentials = None
-        if os.getenv("MSI_ENDPOINT"):
+        if os.getenv("MSI_ENDPOINT") and os.getenv("MSI_SECRET"):
             credentials = MSIAuthentication(
                 resource=self.AUTH_RESOURCE
             )


### PR DESCRIPTION
Azure App Service populates the MSI_ENDPOINT environment variable once MSI is setup on the App Service. This logic now checks if MSI is enabled and setup properly instead of if the code is running in an App Service.

There is a chance MSI is enabled but the App Service hasn't set it up yet. Is this case MSI_ENDPOINT would be blank and falling back to a Service Principal is an acceptable solution (chances are it's not setup either and raising an AuthenticationError would be correct).

More information about the MSI specific environment variables are [here](https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity#using-the-rest-protocol).